### PR TITLE
Fix video ID at path The Editor > Editing Objects > 2. Groups

### DIFF
--- a/content/docs/guides/The Editor/Editing Objects.md
+++ b/content/docs/guides/The Editor/Editing Objects.md
@@ -55,7 +55,7 @@ Here’s how to add groups:
 4. Alternatively, click P to make the object the Parent Group, which will once again be covered in the Groups guide.
 5. To delete a group, click its number in the Group Box. To remove an object from Parent Group, click its number once.
 
-{{< youtube KokRk54 >}}
+{{< youtube 6gg-KokRk54>}}
 
 # 3: Extra Tabs
 


### PR DESCRIPTION
The video ID at this path was previously incomplete (KokRk54 instead of 6gg-KokRk54), this fixes it.

I have not tested to make sure this works as I'm using the browser version of GitHub and don't have the repository installed (I removed an unnecessary space after the ID that other videos don't have, however this may break it) but it's a fairly minor change so it should work fine.