### PR TITLE
chore: npm security updates

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,6 +47,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Update npm
+        run: |
+          npm install -g npm@11.10.1
+          npm -v
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/pr-testing.yaml
+++ b/.github/workflows/pr-testing.yaml
@@ -25,6 +25,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Update npm
+        run: |
+          npm install -g npm@11.10.1
+          npm -v
+
       - name: Install Node.js dependencies
         run: |
           [[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+save-exact=true
+engine-strict=true
+fund=false
+audit=true
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@thulite/inline-svg": "1.2.0",
         "@thulite/seo": "2.4.1",
         "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
         "thulite": "2.6.3"
       },
       "devDependencies": {
@@ -25,8 +26,7 @@
         "vite": "7.3.2"
       },
       "engines": {
-        "node": ">=20.11.0",
-        "npm": ">=11.10.0"
+        "node": ">=20.11.0"
       }
     },
     "node_modules/@babel/cli": {
@@ -4135,10 +4135,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4135,8 +4135,8 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
@@ -5068,7 +5068,7 @@
       "license": "SEE LICENSE IN README",
       "dependencies": {
         "invariant": "2.2.2",
-        "lodash": "^4.18.0"
+        "lodash": "^4.17.4"
       },
       "engines": {
         "node": ">=6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4142,8 +4142,8 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
@@ -5075,7 +5075,7 @@
       "license": "SEE LICENSE IN README",
       "dependencies": {
         "invariant": "2.2.2",
-        "lodash": "^4.17.4"
+        "lodash": "^4.18.0"
       },
       "engines": {
         "node": ">=6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,24 @@
       "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
-        "@tabler/icons": "^3.34.1",
-        "@thulite/doks-core": "^1.8.3",
-        "@thulite/images": "^3.3.1",
-        "@thulite/inline-svg": "^1.2.0",
-        "@thulite/seo": "^2.4.1",
-        "thulite": "^2.6.3"
+        "@tabler/icons": "3.34.1",
+        "@thulite/doks-core": "1.8.3",
+        "@thulite/images": "3.3.1",
+        "@thulite/inline-svg": "1.2.0",
+        "@thulite/seo": "2.4.1",
+        "js-yaml": "4.1.1",
+        "thulite": "2.6.3"
       },
       "devDependencies": {
-        "@changesets/changelog-github": "^0.5.1",
-        "@changesets/cli": "^2.29.5",
-        "prettier": "^3.6.2",
-        "purgecss-whitelister": "^2.4.0",
-        "vite": "^7.3.2"
+        "@changesets/changelog-github": "0.5.1",
+        "@changesets/cli": "2.31.0",
+        "prettier": "3.6.2",
+        "purgecss-whitelister": "2.4.0",
+        "vite": "7.3.2"
       },
       "engines": {
-        "node": ">=20.11.0"
+        "node": ">=20.11.0",
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@babel/cli": {
@@ -1546,13 +1548,13 @@
       }
     },
     "node_modules/@changesets/apply-release-plan": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.0.tgz",
-      "integrity": "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
+      "integrity": "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/config": "^3.1.3",
+        "@changesets/config": "^3.1.4",
         "@changesets/get-version-range-type": "^0.4.0",
         "@changesets/git": "^3.0.4",
         "@changesets/should-skip-package": "^0.1.2",
@@ -1584,14 +1586,14 @@
       }
     },
     "node_modules/@changesets/assemble-release-plan": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz",
-      "integrity": "sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
+      "integrity": "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/get-dependents-graph": "^2.1.4",
         "@changesets/should-skip-package": "^0.1.2",
         "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
@@ -1609,31 +1611,31 @@
       }
     },
     "node_modules/@changesets/changelog-github": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.2.tgz",
-      "integrity": "sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.1.tgz",
+      "integrity": "sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/get-github-info": "^0.7.0",
+        "@changesets/get-github-info": "^0.6.0",
         "@changesets/types": "^6.1.0",
         "dotenv": "^8.1.0"
       }
     },
     "node_modules/@changesets/cli": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.30.0.tgz",
-      "integrity": "sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.0.tgz",
+      "integrity": "sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/apply-release-plan": "^7.1.0",
-        "@changesets/assemble-release-plan": "^6.0.9",
+        "@changesets/apply-release-plan": "^7.1.1",
+        "@changesets/assemble-release-plan": "^6.0.10",
         "@changesets/changelog-git": "^0.2.1",
-        "@changesets/config": "^3.1.3",
+        "@changesets/config": "^3.1.4",
         "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.3",
-        "@changesets/get-release-plan": "^4.0.15",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/get-release-plan": "^4.0.16",
         "@changesets/git": "^3.0.4",
         "@changesets/logger": "^0.1.1",
         "@changesets/pre": "^2.0.2",
@@ -1659,14 +1661,14 @@
       }
     },
     "node_modules/@changesets/config": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.3.tgz",
-      "integrity": "sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
+      "integrity": "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/get-dependents-graph": "^2.1.4",
         "@changesets/logger": "^0.1.1",
         "@changesets/should-skip-package": "^0.1.2",
         "@changesets/types": "^6.1.0",
@@ -1686,9 +1688,9 @@
       }
     },
     "node_modules/@changesets/get-dependents-graph": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz",
-      "integrity": "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
+      "integrity": "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1699,9 +1701,9 @@
       }
     },
     "node_modules/@changesets/get-github-info": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.7.0.tgz",
-      "integrity": "sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.6.0.tgz",
+      "integrity": "sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1710,14 +1712,14 @@
       }
     },
     "node_modules/@changesets/get-release-plan": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.15.tgz",
-      "integrity": "sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
+      "integrity": "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/assemble-release-plan": "^6.0.9",
-        "@changesets/config": "^3.1.3",
+        "@changesets/assemble-release-plan": "^6.0.10",
+        "@changesets/config": "^3.1.4",
         "@changesets/pre": "^2.0.2",
         "@changesets/read": "^0.6.7",
         "@changesets/types": "^6.1.0",
@@ -2838,9 +2840,9 @@
       ]
     },
     "node_modules/@tabler/icons": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.41.1.tgz",
-      "integrity": "sha512-OaRnVbRmH2nHtFeg+RmMJ/7m2oBIF9XCJAUD5gQnMrpK9f05ydj8MZrAf3NZQqOXyxGN1UBL0D5IKLLEUfr74Q==",
+      "version": "3.34.1",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.34.1.tgz",
+      "integrity": "sha512-9gTnUvd7Fd/DmQgr3MKY+oJLa1RfNsQo8c/ir3TJAWghOuZXodbtbVp0QBY2DxWuuvrSZFys0HEbv1CoiI5y6A==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2882,42 +2884,41 @@
       }
     },
     "node_modules/@thulite/doks-core": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@thulite/doks-core/-/doks-core-1.9.3.tgz",
-      "integrity": "sha512-K4BssyW7LwA19fz628kkdWb9p+DMq1LawmkegNEHkXnz7kecO3lVldk/Yn5mm9Ib6tv32ECA61BQxefDD9XokQ==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@thulite/doks-core/-/doks-core-1.8.3.tgz",
+      "integrity": "sha512-qGPlWACP40PDbhQdjK/n5Vmjd72K47qHt0Wtb3l9PeXAl+QYHyghedZuoJIZcehwC17fqiSuwThY5M9A1DABgw==",
       "license": "MIT",
       "dependencies": {
-        "@thulite/bootstrap": "^1.2.3",
-        "basiclightbox": "^5.0.4",
+        "@thulite/bootstrap": "^1.2.2",
         "clipboard": "^2.0.11",
-        "flexsearch": "^0.8.212"
+        "flexsearch": "^0.8.205"
       },
       "engines": {
         "node": ">=20.11.0"
       }
     },
     "node_modules/@thulite/images": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@thulite/images/-/images-3.3.4.tgz",
-      "integrity": "sha512-l7fYyBFiiZWgFkaBLkINDrzDZ+KXTxWnvhTVPPEysL+TexzEubTY7b5s00iQoFZsUg4m+6flbYxZSupydFrEHg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@thulite/images/-/images-3.3.1.tgz",
+      "integrity": "sha512-PG+Qb11AgCIhbaYWsVZknMTOgQXD9IPxNDDg4DvSyIYivDjxwPVvZX9LdHdbiaL+4aKcibfuWY4rtrJAcG5n8Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.11.0"
       }
     },
     "node_modules/@thulite/inline-svg": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@thulite/inline-svg/-/inline-svg-1.2.2.tgz",
-      "integrity": "sha512-jbxeXQjJT5HFuRufckEbEAoZjHJZCHwLY/rjJS6Lhc9ZZuMMp6QaOVk4pJa0Ey1UBsTJLcACyfm/K47oGJBluQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@thulite/inline-svg/-/inline-svg-1.2.0.tgz",
+      "integrity": "sha512-ffibNW17QJfwkPqe+AlIyCJFQiNqVQ9eFFsftPqQxx4CzVyP8HyYQUkWdgLFaxqWLN7ErxqNoC1Ibcmflqwm1w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.11.0"
       }
     },
     "node_modules/@thulite/seo": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@thulite/seo/-/seo-2.4.3.tgz",
-      "integrity": "sha512-1Y8PJXjGQBoB+VgcC3+RiPxGyI0VshBgufloOtPGlolB+K+qSMY9SPla1mL2HzkLbteb2W9+9CktS7CA/f90Rg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@thulite/seo/-/seo-2.4.1.tgz",
+      "integrity": "sha512-ZHGud+gNZLjWP9WgxfA8t4H1+8Ql8xodnUnBA6QIJ/mKKhBYnomqCjFaeYE1t/5khglHrofyZagn0JXiaQ0NaA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.11.0"
@@ -2981,7 +2982,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -3095,12 +3095,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/basiclightbox": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/basiclightbox/-/basiclightbox-5.0.4.tgz",
-      "integrity": "sha512-EsuNWmfcFXWZOe0txKXsllYOC7bDpoaVLc4HHHlYKB/roymlZs+FBdLUU6rx2yPpnJZhulwheKdPjqr2k0+NGQ==",
-      "license": "MIT"
     },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
@@ -4067,7 +4061,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4673,9 +4666,9 @@
       "license": "MIT"
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5088,9 +5081,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5257,12 +5250,12 @@
       }
     },
     "node_modules/thulite": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/thulite/-/thulite-2.6.5.tgz",
-      "integrity": "sha512-TmKAwxv7lWVBau7EE6aJhh1swdm+d1Qo50ZkFcNo+WQfXAEoXsvPc2M7f+DxgTErYg3SN1Qy9Ael8dgsX/npiQ==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/thulite/-/thulite-2.6.3.tgz",
+      "integrity": "sha512-bT5A64nqlChrhp2lvCLP2z4HJhLWjaMfKjLWqpmqdNyaFowz4vTG7NzvuHKo2AElsAwChMdgRZpb9r1u+wM4QQ==",
       "license": "MIT",
       "dependencies": {
-        "@thulite/core": "^1.5.9"
+        "@thulite/core": "^1.5.5"
       },
       "engines": {
         "node": ">=20.11.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@thulite/inline-svg": "1.2.0",
     "@thulite/seo": "2.4.1",
     "js-yaml": "4.1.1",
+    "lodash": "4.18.1",
     "thulite": "2.6.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "vite": "7.3.2"
   },
   "engines": {
-    "node": ">=20.11.0",
-    "npm": ">=11.10.0"
+    "node": ">=20.11.0"
   },
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -17,22 +17,24 @@
     "preview": "vite preview --outDir public"
   },
   "dependencies": {
-    "@tabler/icons": "^3.34.1",
-    "@thulite/doks-core": "^1.8.3",
-    "@thulite/images": "^3.3.1",
-    "@thulite/inline-svg": "^1.2.0",
-    "@thulite/seo": "^2.4.1",
-    "thulite": "^2.6.3"
+    "@tabler/icons": "3.34.1",
+    "@thulite/doks-core": "1.8.3",
+    "@thulite/images": "3.3.1",
+    "@thulite/inline-svg": "1.2.0",
+    "@thulite/seo": "2.4.1",
+    "js-yaml": "4.1.1",
+    "thulite": "2.6.3"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.5.1",
-    "@changesets/cli": "^2.29.5",
-    "prettier": "^3.6.2",
-    "purgecss-whitelister": "^2.4.0",
-    "vite": "^7.3.2"
+    "@changesets/changelog-github": "0.5.1",
+    "@changesets/cli": "2.31.0",
+    "prettier": "3.6.2",
+    "purgecss-whitelister": "2.4.0",
+    "vite": "7.3.2"
   },
   "engines": {
-    "node": ">=20.11.0"
+    "node": ">=20.11.0",
+    "npm": ">=11.10.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## What Changed:
- A `.npmrc` file was created. It checks that dependencies use the exact versions stated at `package.json`, checks `audit` for possible vulnerabilities, and sets `min-release-age` to 7 days to prevent installing malicious packages.
- The `npm` version used at `deploy.yaml` and `pr-testing.yaml` was bumped from 11.8.0 to 11.10.1. This allows the usage of  the `min-release-age` option at `.npmrc`. Users must use npm 11.10.1 or higher so that the `min-release-age` parameter is considered.
- lodash was bumped from 4.17.23 to 4.18.1 to avoid the following security issue: https://security.snyk.io/package/npm/lodash/4.17.23.

`npm audit` runs with 0 vulnerabilites now.