### PR TITLE
Add missing media on triggers 2 guides

### DIFF
--- a/content/docs/guides/triggers-2/attempt-based-data-1-2-1.md
+++ b/content/docs/guides/triggers-2/attempt-based-data-1-2-1.md
@@ -36,49 +36,49 @@ This technique works by abusing the way the game handles collisions. When a Coll
 
 This setup will involve three parts: The Collision blocks themselves, the Collision triggers, and the Move triggers that make everything work.
 
-**Collision blocks**
+## Collision blocks
 
-- **1.** Place down a collision block and assign it to block ID `A`. Enable the Dynamic Block setting and assign the block to Group `A`.
-- **2.** Place down two collision blocks, one on top of the other, a few grid spaces to the right of the one you placed in the last step. Assign one of them to block ID `B` and Group `B` and the other to block ID `C` and Group `C.`
-- **3.** Place down a Move Trigger. Set the Move X value to 10*the grid spaces and the Target Group to Group `A`.
+1. Place down a collision block and assign it to block ID `A`. Enable the Dynamic Block setting and assign the block to Group `A`.
+2. Place down two collision blocks, one on top of the other, a few grid spaces to the right of the one you placed in the last step. Assign one of them to block ID `B` and Group `B` and the other to block ID `C` and Group `C.`
+3. Place down a Move Trigger. Set the Move X value to 10*the grid spaces and the Target Group to Group `A`.
 
-{{< img src="https://lh3.googleusercontent.com/d/1FIIPY4iyV7oZhjwxW7MadBTIanOzNUyO" >}}
+{{< youtube v1DrVDCTs5U >}}
 
 You should end up with something like this.
 
 {{< img src="https://lh3.googleusercontent.com/d/15r6nZIWZ9Vh9JFVlSrnquSx209ADukot" >}}
 
-**Collision triggers**
+## Collision triggers
 
 These triggers will use the priority of the collision blocks to set an Item ID’s value to 0 or 1.
 
 - If block `B` has the higher priority, block `C` will be Toggled off, setting the Item ID's value to 0.
 - If block `C` has the higher priority, the Pickup trigger will be activated, setting the Item ID’s value to 1.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1t_G8z4BHSodj96j2Qmy9_tgGliaiMCFn" >}}
 
 To set up the collision triggers, follow the instructions below.
 
-- **1.** Place down a Collision Trigger and set the BlockA value to block ID `A`. Set the BlockB value to ID `B`, and set the Target ID to Group `C`. Ensure that Activate Group is _not_ enabled.
-- **2.** Place down another Collision Trigger. Set the BlockA value to block ID `A`, the BlockB value to ID `C`, and the Target ID to a new Group `D`. Activate Group *should* be enabled here.
-- **3.** Place down a Pickup Trigger, and make it add 1 to a new Item ID `A`. Select ‘Spawn triggered’, and assign it to Group `D`.
+1. Place down a Collision Trigger and set the BlockA value to block ID `A`. Set the BlockB value to ID `B`, and set the Target ID to Group `C`. Ensure that Activate Group is _not_ enabled.
+2. Place down another Collision Trigger. Set the BlockA value to block ID `A`, the BlockB value to ID `C`, and the Target ID to a new Group `D`. Activate Group *should* be enabled here.
+3. Place down a Pickup Trigger, and make it add 1 to a new Item ID `A`. Select ‘Spawn triggered’, and assign it to Group `D`.
 
-{{< img src="https://lh3.googleusercontent.com/d/1_yDrtKKNhJVsM8NbNzrqRX5e7LOmqJ6J" >}}
+{{< youtube Qggj7lPTErc >}}
 
 Your setup should now resemble this.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/17QD7DyItEV8p8yZoRliRYSmW7Qv5PghS" >}}
 
-- **Move triggers**
+## Move triggers
 
 Here, we'll set up the move triggers that actually change the Priority Order.
 
-- **1.** Place down a Move Trigger and set the Target ID to Group `B`, the Move Time to 0, and the Move X value to 50.
-- **2.** Place down a new Move Trigger one block to the right of the first. Set the Target ID to Group `B`, the Move Time to 0.03, and the Move X value to -50.
-- **3.** Make sure both triggers are Spawn Triggered and assign them to a new Group `E`.
-- **4.** Place down two more Move triggers with the same setup, but set their Target Groups to Group `C` and add both to a new Group `F`.
+1. Place down a Move Trigger and set the Target ID to Group `B`, the Move Time to 0, and the Move X value to 50.
+2. Place down a new Move Trigger one block to the right of the first. Set the Target ID to Group `B`, the Move Time to 0.03, and the Move X value to -50.
+3. Make sure both triggers are Spawn Triggered and assign them to a new Group `E`.
+4. Place down two more Move triggers with the same setup, but set their Target Groups to Group `C` and add both to a new Group `F`.
 
-{{< img src="https://lh3.googleusercontent.com/d/1ojmgaFxyJ2azgrfWchoZ1LG97OK5CpEt" >}}
+{{< youtube 4EK_QiZRwDU >}}
 
 Your Move Trigger setup should now look something like this.
 

--- a/content/docs/guides/triggers-2/attempt-based-data-2-2-1.md
+++ b/content/docs/guides/triggers-2/attempt-based-data-2-2-1.md
@@ -39,13 +39,13 @@ When we refer to the base of a counting system, we mean the maximum number of va
 
 Numbers in binary are made of binary digits (bits for short). __Each bit represents a power of 2, starting with 2⁰ (or 1), and this value can increase indefinitely__. You can work out the maximum value you can store in a given number of bits with the formula 2ⁿ - 1, where n is the number of bits you have. With 7 bits, for example, the maximum number you can store is 2⁷ - 1, or 127.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/18Y1qGWPyqCfCA7bJ06gUwtS5VnJTkMkL" >}}
 
 ## Converting Binary to Decimal
 
 Converting from binary to decimal is a rather straightforward process. You simply need to add the value of every bit with a 1 in it to a decimal total. For example, here’s how we convert the binary number 0010110 into decimal to achieve a result of 22.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1B37MZP_94IPm29zHdSId_Lyl7OfzbZTs" >}}
 
 Converting from decimal to binary is a bit more complex. You’ll need to start by finding the largest power of 2 that’s smaller than your number. Once you’ve got that value, you’ll need to subtract it from your number and put a 1 in its corresponding bit.
 
@@ -53,7 +53,7 @@ Next, compare every power of 2 below the one you just subtracted to your new num
 
 For example, here’s the process of converting the number 22 back into binary:
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1oCrZyEdF4EYzDF7A76DPWDvSMc-b_p5o" >}}
 
 # 2: Setup
 
@@ -63,33 +63,32 @@ The setup for the save consists of four modules: the binary saves that save and 
 
 To save decimal values, you’ll need to have a clear maximum value in mind, because you can’t do it without making binary saves (and you can’t save infinite binary values). Once you choose your maximum value, convert it to binary and keep the number of bits in mind.
 
-- **1.** Begin by creating a binary save system (refer to **Attempt-Based Data 1** for instructions), but make sure you leave out the four Move triggers that save the value. If you want, you can assign the Pickup trigger and Collision Block `C` to the same Group; this saves one Group per digit and make future steps easier._
-- **2.** Make both of the Collision triggers Spawn-triggered and assign them to a new Group `A`.
-- **3.** Place down a Spawn trigger at the very start of the level and make it target Group `A`.
-- **4.** Copy-paste the entire system, excluding the new Spawn trigger. Move it at least four grid spaces away on the X-axis (as the Y-axis is irrelevant to the Blocks’ priority order) and use Build Helper to update all the Groups.
-- **5.** Select the Pickup trigger and open the Edit Object menu. There, click the :BluePlus: icon next to the Item ID field to target the next free Item ID.
-- **6.** Do the same for all of the Collision blocks’ Block ID fields, and update the Collision triggers accordingly.
-- **7.** Repeat steps `4` to `6` until the number of binary saves matches the number of bits for your maximum value.
+1. Begin by creating a binary save system (refer to **Attempt-Based Data 1** for instructions), but make sure you leave out the four Move triggers that save the value. If you want, you can assign the Pickup trigger and Collision Block `C` to the same Group; this saves one Group per digit and make future steps easier._
+2. Make both of the Collision triggers Spawn-triggered and assign them to a new Group `A`.
+3. Place down a Spawn trigger at the very start of the level and make it target Group `A`.
+4. Copy-paste the entire system, excluding the new Spawn trigger. Move it at least four grid spaces away on the X-axis (as the Y-axis is irrelevant to the Blocks’ priority order) and use Build Helper to update all the Groups.
+5. Select the Pickup trigger and open the Edit Object menu. There, click the :BluePlus: icon next to the Item ID field to target the next free Item ID.
+6. Do the same for all of the Collision blocks’ Block ID fields, and update the Collision triggers accordingly.
+7. Repeat steps `4` to `6` until the number of binary saves matches the number of bits for your maximum value.
 
-None
+{{< youtube OS1_ubhnWEE >}}
 
 You should end up with something like this.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1aolfJa0i77Sdje_vwAdoeGGXOlluNcCu" >}}
 
 ## Converting Binary to Decimal
 
 This step is the same inside and outside GD. We simply need to test for bits that have a value of 1, and add those bits’ values together. This can be achieved with a simple Instant Count and Pickup trigger-based setup.
 
-- **1.** Begin by placing down a Spawn trigger after all the binary saves have activated and setting its Target Group to a new Group `B`.
-- **2.** Place an Instant Count trigger. Make it Spawn Triggered, assign it to Group `B`, and enable Activate Group. Then, make the Item ID the ID of the bit you're testing, the Target Count 1, and the Target ID a new group `C`.
-- We recommend that you go in ascending order of Item IDs for the bits - with the lowest ID representing the **most significant bit**, or the bit with the highest number value. However, you can do it any way you like.
-- **3.** Place down a Pickup trigger and set the Item ID to a new ID `X` (this ID will represent the decimal value you’re saving). Set the Count to the value of the bit. For example, since this is the most significant bit, its value would be 128 in an 8-bit system.
-- **4.** Copy-paste the two triggers and use Build Helper to change their Groups.
-- **5.** Set the Instant Count trigger and Pickup triggers’ Item IDs to the one for the next bit, and halve the number in the Pickup trigger’s Count field.
-- **6.** Repeat steps `4` and `5` until you reach the final bit, with a value of 1 in the Pickup trigger’s Count field.
+1. Begin by placing down a Spawn trigger after all the binary saves have activated and setting its Target Group to a new Group `B`.
+2. Place an Instant Count trigger. Make it Spawn Triggered, assign it to Group `B`, and enable Activate Group. Then, make the Item ID the ID of the bit you're testing, the Target Count 1, and the Target ID a new group `C`. We recommend that you go in ascending order of Item IDs for the bits with the lowest ID representing the **most significant bit**, or the bit with the highest number value. However, you can do it any way you like.
+3. Place down a Pickup trigger and set the Item ID to a new ID `X` (this ID will represent the decimal value you’re saving). Set the Count to the value of the bit. For example, since this is the most significant bit, its value would be 128 in an 8-bit system.
+4. Copy-paste the two triggers and use Build Helper to change their Groups.
+5. Set the Instant Count trigger and Pickup triggers’ Item IDs to the one for the next bit, and halve the number in the Pickup trigger’s Count field.
+6. Repeat steps `4` and `5` until you reach the final bit, with a value of 1 in the Pickup trigger’s Count field.
 
-None
+{{< youtube iPMHdaZa7gE >}}
 
 Your result should resemble this (but potentially expanded to include however many values you would like, of course).
 
@@ -105,34 +104,32 @@ This part of the system will reset all saved binary digits to 0. We’re doing t
 - **4.** Finally, assign both triggers to Group `D`.
 - **5.** Repeat steps `2` and `3` for each binary save, updating the Move triggers’ Target Groups accordingly. Make sure to keep all of the triggers on Group `D` when you’re done.
 
-None
+{{< youtube DDk-OsRNoIg >}}
 
 What you end up with should look something like this.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1lS7bwkUdkHXxhj2PgkN3gnHObr8cPxkt" >}}
 
 ## Converting Decimal to Binary
 
 Finally, we'll convert our decimal value to binary and send it forward to the next attempt. Similar to how we did this conversion the other way round, we can do it the same way we’d do it outside GD with a simple Instant Count and Pickup trigger-based setup. However, we’ll need to add something extra to make this work smoothly with our binary save systems.
 
-- **1.** Place a Spawn trigger and set its Target Group ID to a new Group `E` (in the future, this trigger can be replaced with whatever trigger you want to activate the save).
-- **2.** Place down an Instant Count trigger. Set the Item ID field to Item ID `X`. Set the Target Count to _one less than the value of your binary number’s most significant bit_ (in an 8-bit number this would be 127), and enable the “Larger” parameter. Finally, set the Target ID to a new Group `F`, assign the trigger to Group `E` and ensure that “Spawn Triggered” is enabled. _This trigger is what’s checking if a certain power of 2 can fit into our decimal number._
+1. Place a Spawn trigger and set its Target Group ID to a new Group `E` (in the future, this trigger can be replaced with whatever trigger you want to activate the save).
+2. Place down an Instant Count trigger. Set the Item ID field to Item ID `X`. Set the Target Count to _one less than the value of your binary number’s most significant bit_ (in an 8-bit number this would be 127), and enable the “Larger” parameter. Finally, set the Target ID to a new Group `F`, assign the trigger to Group `E` and ensure that “Spawn Triggered” is enabled. _This trigger is what’s checking if a certain power of 2 can fit into our decimal number._
+3. Place down a Pickup trigger. Make it target Item ID `X`, and make it subtract the most significant bit’s value (so for an 8-bit number, the count would be -128). Finally, make it Spawn Triggered.
+4. Place down a Move trigger. Set the Target ID to Group `B`. Set the Move Time to 0, the Move X value to 40, and make it Spawn Triggered.
+5. Duplicate this trigger, set the new trigger’s Move Time to 0.03, and set its Move X value to -40.
+6. Add both Move triggers and the Pickup trigger from step `3` to Group `F`. _These triggers will subtract the bit’s value from the decimal number and set the bit itself to 1_.
+7. Duplicate the triggers from steps `2` to `6` and use Build Helper. Next, ensure that the new Instant Count trigger is placed _at least one grid space to the right of the previous one_.
+8. Set the Instant Count trigger’s Target Count to *one less* than the value of the next bit (63, 31, 15, etc.), and update the Pickup trigger accordingly. You’ll also need to update the Move triggers’ Target Group IDs to match the corresponding block in the next binary save.
+9. Repeat step `8` for each binary save.
 
-- **3.** Place down a Pickup trigger. Make it target Item ID `X`, and make it subtract the most significant bit’s value (so for an 8-bit number, the count would be -128). Finally, make it Spawn Triggered.
-- **4.** Place down a Move trigger. Set the Target ID to Group `B`. Set the Move Time to 0, the Move X value to 40, and make it Spawn Triggered.
-- **5.** Duplicate this trigger, set the new trigger’s Move Time to 0.03, and set its Move X value to -40.
-- **6.** Add both Move triggers and the Pickup trigger from step `3` to Group `F`. _These triggers will subtract the bit’s value from the decimal number and set the bit itself to 1_.
-
-- **7.** Duplicate the triggers from steps `2` to `6` and use Build Helper. Next, ensure that the new Instant Count trigger is placed _at least one grid space to the right of the previous one_.
-- **8.** Set the Instant Count trigger’s Target Count to *one less* than the value of the next bit (63, 31, 15, etc.), and update the Pickup trigger accordingly. You’ll also need to update the Move triggers’ Target Group IDs to match the corresponding block in the next binary save.
-- **9.** Repeat step `8` for each binary save.
-
-None
+{{< youtube vd-2DdjE-HA >}}
 
 Your final product should resemble this.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1sJABpe8NruNrBxIYBzEvJfdP2FhLxFME" >}}
 
 Here's an example of what you can do with this setup; here, the counter increases by 1111 each attempt.
 
-None
+{{< youtube mPntGMPYrqI >}}

--- a/content/docs/guides/triggers-2/camera-simulation-2-1.md
+++ b/content/docs/guides/triggers-2/camera-simulation-2-1.md
@@ -55,7 +55,7 @@ Search for this level with the ID: `90903111` in order to check the camera simul
 
 Gamemode portals with fixed borders can move the camera depending on their Y-position. While locking the visuals in the X-position is simple, the Y-position is where things get tricky.
 
-{{< img src="https://lh3.googleusercontent.com/d/1VQ3DroGjgLfe679BfHCdt2oFAEHUNlIS" >}}
+{{< youtube QNWsIklQGv8 >}}
 
 You can simulate this movement into your objects with the help of a move trigger. From trial and error, the move trigger’s setup needs to have these units so that your objects can match with the camera’s movements, regardless of the Y units you add. Though as a safeguard, keep your Y units below `50` units.
 
@@ -63,7 +63,7 @@ You can simulate this movement into your objects with the help of a move trigger
 
 However, where should you place this move trigger? Do you snap it in the same grid with the portal? For simple camera locking, yes. This is because the portal’s hitbox and the move trigger’s hitbox would align perfectly.
 
-{{< img src="https://lh3.googleusercontent.com/d/1zIbh-SLUk0Hu_JhFusYB-BKaF7-6UFAN" >}}
+{{< youtube Z0J_uTAQ4MU >}}
 
 However, refresh rates complicate things. Depending on your game’s refresh rate, it detects the timing of your camera differently. This is not really an issue when it comes to simple camera visuals, but with more complexity in parallax, this needs to be taken into account. This will be more taxing for the borderless camera setup later.
 
@@ -81,27 +81,27 @@ Starting a camera movement will automatically negate all camera movements before
 
 1. The first move trigger instantly moves a one-object group up and down depending on the portal’s trend. Place this to the left of each portal.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1k6FYcsEJAFSMcVYWwQQ_5sl0xUJGhvL9" >}}
 
 2. The second move trigger has Use Target where another one-object group moves to the previous group’s target position in step 1. Set the easing to “Ease In Out” with 1.4 easing rate and 0.4s move time. This will be spawn-triggered and multi-triggered to 2 more groups.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1rwp3OBkhvVWDe5VUt7K6YJhsr9XQ5777" >}}
 
 3. A touch-triggered spawn trigger is exactly aligned with the portal to activate the object in Step 2. Meanwhile, a stop trigger is placed slightly to the left of the spawn trigger to interrupt the camera movement. Set both of these to a Follow Player Y trigger to ensure they will be touched.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/14CY4NbEbejeyuGK2jnPLOSNg5sQPMq61" >}}
 
 4. Group your visuals to a follow trigger with the follow ID from Step 2. Locking visuals will have `0` in the X-Mod and `1.00` in the Y-Mod. If you need vertical parallax, add another follow trigger and change the Y-mod to your liking.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/16O2ACE8KGV72ZAgVnTJCtxWeSFpOUF7X" >}}
 
 5. Playtest. Slightly move the triggers in Step 1 if the camera fails to move the whole way. The bordered setup is complete!
 
-{{< img src="https://lh3.googleusercontent.com/d/139Zq-uvq24NhxyFw3n-xweIOXhdM1XjO" >}}
+{{< youtube 2wQoWVdrK_E >}}
 
-{{< img src="https://lh3.googleusercontent.com/d/1X32WKG2c8v_9HzHrK12Hud8fb2sWBPAb" >}}
+{{< youtube 0rZnK0kdHeo >}}
 
-{{< img src="https://lh3.googleusercontent.com/d/1bBp4cVypgzpXzYdcKjngJ6H-azHekODF" >}}
+{{< youtube y86shKsuPV0 >}}
 
 However, this is not the only camera setup that you can make.
 
@@ -113,15 +113,15 @@ Search for this level with the ID: `92313313` in order to check the camera simul
 
 However, notice that for the robot and cube gamemode, the camera only moves if the player goes near the screen’s edges, so how would you simulate the camera with that condition? Referring to the trigger workflow, let’s specify the function, module, and truth conditions:
 
-> **Function**: Make the camera visuals lock to a borderless camera in the Y-axis. If the camera goes up by 10 units, the visuals go up by 10 units at the same speed. Because this is borderless, we need to take into account both the top edges and bottom edges of the screen.
+**Function**: Make the camera visuals lock to a borderless camera in the Y-axis. If the camera goes up by 10 units, the visuals go up by 10 units at the same speed. Because this is borderless, we need to take into account both the top edges and bottom edges of the screen.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1PFw5c4cLkuYrvjGnqOh_lIGGxGsCqm09" >}}
 
-> **Module**: You’ll need two sets of collision blocks to build an **adjustment area** to the camera visuals; they are located at the top and bottom of the screen. For normal gravity, the upper adjustment area has 3 blocks, while the lower has 4 blocks. These blocks need to be grouped to a follow trigger where its X-mod needs to be `0` to avoid the blocks from moving horizontally.
+**Module**: You’ll need two sets of collision blocks to build an **adjustment area** to the camera visuals; they are located at the top and bottom of the screen. For normal gravity, the upper adjustment area has 3 blocks, while the lower has 4 blocks. These blocks need to be grouped to a follow trigger where its X-mod needs to be `0` to avoid the blocks from moving horizontally.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1xhGYGdWudaEytDx5sttLC5hCPwCXBBAd" >}}
 
-> **Truth Condition**: Following Pin - A square with a Follow group ID which will move the camera visuals and adjustment area when activated. You’ll want to set the speed of the follow player Y to `0.1`. In this case, there are two truth conditions for the top and bottom areas of the screen. If the player passes either areas, the module will activate.
+**Truth Condition**: Following Pin - A square with a Follow group ID which will move the camera visuals and adjustment area when activated. You’ll want to set the speed of the follow player Y to `0.1`. In this case, there are two truth conditions for the top and bottom areas of the screen. If the player passes either areas, the module will activate.
 
 {{< img src="https://lh3.googleusercontent.com/d/1FBoPg6nlkzj0M6uB8ws-UgOpjn2vlC3u" >}}
 
@@ -136,7 +136,7 @@ Its trigger work will look like this.
 Referencing the image above, seven groups were used for the Y-lock:
 
 - Group `2` makes the camera module and visuals follow the following pin when activated.
- * For vertical parallax, you add two extra follow triggers for each adjustment area targeting a new group, then tweak the Y-Mod numbers to not equal `1.000`.
+- For vertical parallax, you add two extra follow triggers for each adjustment area targeting a new group, then tweak the Y-Mod numbers to not equal `1.000`.
 - Groups ‘3’ and ‘4’ are the following pins when the player touches either adjustment areas. They also follow each other when this happens.
 - Collision triggers that target groups `5` and `8` will activate the camera module and move the visuals. The difference is the adjustment area that it affects. Group `5` targets the top adjustment area while group `8` targets the bottom.
 - Collision triggers which target groups `6` and `9` use “Trigger on Exit”: when the player leaves the adjustment area, the camera stops following the pin.
@@ -164,7 +164,7 @@ Most importantly, set the spawn-triggered triggers as “Multi-trigger”.
 
 - If you have scale hack, you can even reduce the collision box’s size to `0.01` for extra accuracy. This is provided in the uploaded level.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1P0rNeE93typ5RmhVAzKki-w1n48M5QW9" >}}
 
 5. Build the adjustment area and the necessary triggers.
 
@@ -172,7 +172,7 @@ None
 
 6. Playtest.
 
-{{< img src="https://lh3.googleusercontent.com/d/1UQ-1tyktyGsc147Y_ODBvoydoj7FP4WK" >}}
+{{< youtube xwVwxRuRdYo >}}
 
 Now that the main part is finished, it should be able to work without gravity changes. If you want gravity changes, however, there are extra steps to go through.
 
@@ -180,7 +180,7 @@ Now that the main part is finished, it should be able to work without gravity ch
 
 Recall how the bottom adjustment area has one extra collision block than the top? This needs to change when the player goes upside down. Putting the numbers, we need to shift this module downwards by `10` units, then return to its original setup in normal gravity. Referring back to the trigger workflow, switching gravity complicates the module and truth conditions.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1WDCxvMRHBXoOMKB79Ce0GVvkn_n1GCGg" >}}
 
 Adding this setup costs two extra groups for the touch-triggered spawn triggers which act as truth conditions for the gravity changes. However, feel free to replace it with other spawns; for example, when it comes to blue orbs, toggle orbs are much more effective than spawn triggers as they activate alongside touching the blue orbs.
 
@@ -190,13 +190,13 @@ Triggers at the centre activate by either spawn triggers. Think of it as an OR g
 
 The toggle triggers at the bottom acts as a calibration sequence for the camera module. You know how when your laptop suddenly has problems, you turn the laptop off and then on again? That’s what the toggle triggers are doing for the gravity change.
 
-None
+{{< youtube -EogtpAbXrI >}}
 
 Ultimately, the borderless camera setup with gravity changes is complete.
 
-None
+{{< youtube hz6P8tGF9mk >}}
 
-None
+{{< youtube x7TdySbK9E4 >}}
 
 As a precaution, stick to building either the bordered or borderless setup separately.
 

--- a/content/docs/guides/triggers-2/control-schemes.md
+++ b/content/docs/guides/triggers-2/control-schemes.md
@@ -7,6 +7,7 @@ weight: 6160
 date: 2026-03-05T00:00:00.000Z
 contributors:
   - theibra
+  - notamoderatr
 description: When making minigames, controls are a major aspect as they are what the player uses to interact with your level. Making them complicated or confusing can lead to the experience being less enjoyable. However, having only 2 or 6 inputs can make this challenging. This guide discusses how different button combinations can be used to create more actions while keeping the control layout manageable.
 tags:
   - Grade 2
@@ -19,42 +20,20 @@ seo:
 ---
 {{< callout context="caution" title="Incomplete guide" icon="outline/info-circle" >}}
 
-
-
-
-
 This guide is missing the following:
 - Examples
-
-
-
-
-
 
 {{< /callout >}}
 
 {{< callout context="note" title="TLDR - What this guide covers" icon="outline/info-circle" >}}
 
-
-
 * While Geometry Dash only offers so many usable keys, you can add more actions to your level using various trigger setups.
 * Control schemes should be intuitive to the player, making sure they are easy to learn.
-
-
-
 {{< /callout >}}
 
 {{< callout context="tip" title="Note" icon="outline/circle-plus" >}}
 
-
-
-
-
 This guide contains interactive images; you can click or hover over elements to learn more about them.
-
-
-
-
 
 {{< /callout >}}
 
@@ -165,7 +144,7 @@ You may notice with setup A that moving 2 opposite directions at the same time c
 
 * **Overriding the Previous Input**: Event Trigger 1 activates a Stop Trigger that stops the loop of the opposite direction, and vice versa for Event Trigger 2.
 * **Changing Directions after Releasing a Key**: Event Trigger 1 activates a Pause Trigger that pauses the Event Trigger of the opposite direction, Event Trigger 2 activates a resume trigger that resumes it.
- 
+
 These solutions can also be used to limit your options to 4 directions!
 
 ## Driving controls
@@ -252,7 +231,7 @@ You can switch out the delayed Spawn Triggers for Event triggers detecting \[key
 
 ## Buttons
 
-Buttons usually require controls separate from the player's movement, but you might want to implement a different approach depending on the usecase. 
+Buttons usually require controls separate from the player's movement, but you might want to implement a different approach depending on the usecase.
 
 For the following examples that don’t use the player as a cursor, we will use a Collision Block. Collision can be detected by using the Collision Trigger and toggling the block, or by spawning an Instant Collision Trigger.
 

--- a/content/docs/guides/triggers-2/priority-order.md
+++ b/content/docs/guides/triggers-2/priority-order.md
@@ -24,11 +24,12 @@ tags:
 {{< /callout >}}
 
 ** **
+
 # 1: Priority Order
 
 Geometry dash is separated into invisible sections 100 units (3.33 blocks) wide, and infinitely tall. They can’t be seen in the editor, but if you could see them they’d look like the orange lines in the image below. These sections help determine the priority or order that objects or triggers activate.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1j03rQYlowQdWY40gikt6-AiBH8EoGMyT" >}}
 
 The rules for Priority Order are as follows:
 
@@ -42,19 +43,19 @@ Remember that Priority Order doesn’t care about an object’s X position, as l
 
 Here’s an example of Priority Order at work. The yellow orb has a priority of `1`, as it’s the first object in this section.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1igrVte49FH2rvXM7YIk67MZhzbwY5ax8" >}}
 
 The purple orb is placed within the same section as the yellow orb, so it gets the lowest priority of `2`.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1BRzrK0osfUfqDp6Je0Fed8jqZ6UxIrrV" >}}
 
 The red orb is added to the section to the left of the other two orbs. It gets the highest priority since it’s in the leftmost section.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1vATFKk3YRiyCcqrC63dgm4sV4wY_RrE1" >}}
 
 The red orb is moved into the section with the other two orbs, so it gets the lowest priority. The purple and yellow orb gain priority as a result.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/148rDtgT2mgg9w0OQepJBB6opYSv0Jusz" >}}
 
 The best way to check an object’s priority is through layering. If two objects share the same Z layers and Z order, the object in front will have lower priority than the object behind it. This will only update in the editor when you save & exit, then re-enter the level.
 
@@ -67,15 +68,15 @@ Changing the Priority Order of two objects in the same section is fairly easy. T
 
 For example, the yellow orb in this image has a priority of `1` while the purple one has a priority of `2`.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1tCYmZPOFpkJzBRlfdK_OdgN5vI0g-fnk" >}}
 
 Moving the yellow orb into the next section resets its priority.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1kALNPDIu8YlOYmqw7TbFIvlEbLdTYvjk" >}}
 
 Then, the yellow orb is moved back - resetting its priority and switching the locations of the orbs on the priority list.
 
-None
+{{< img src="https://lh3.googleusercontent.com/d/1LFzcqzkE0WpbMXkLg22qQTcZe8P15fsc" >}}
 
 This can be done inside a level with move triggers, and lets you change the priority of orbs, collision blocks, and object Z layers. However, it’s much more finnicky for triggers because they can’t be moved on the X axis using move triggers.
 
@@ -87,7 +88,7 @@ Most importantly, this info will only save when you’re inside the level. If yo
 
 Here is a basic example of using portals of saving data. In the video below, you enter the portal with the highest priority taking you to one place. The portal is then moved to the right and back, setting it to the lowest priority. On the next attempt, you enter through the other portal as it has a higher priority.
 
-None
+{{< youtube JPyb8Dc-xVg >}}
 
 Be aware that *Priority Order does NOT save between attempts in 2.2, only in 2.1*. However, Update 2.2 also introduces the **Order** system which also impacts how triggers work.
 
@@ -102,23 +103,27 @@ In certain cases, the game will order what triggers activate first to prevent un
 In order to eliminate randomness, triggers activated on the same frame happen in a set order, much like how a calculator processes mathematical operations. The game uses 3 different ordering algorithms to achieve this.
 
 ## Left to Right Priority
+
 If "spawn triggered" is enabled, triggers will be activated from left to right, meaning the leftmost triggers will activate first, cascading until the last trigger is activated.
 
 {{< youtube Wy4kVg7cxmA >}}
 
-## Order Value Priority:
+## Order Value Priority
+
 **As of 2.206, this feature suffers from multiple bugs, and should be avoided when possible until it’s fixed.** This can trigger on portals, pads, and orbs but has no visible effects. This can also break triggers if they aren’t set up properly.
 
 This feature is only used for regular or touch-enabled triggers. Their order values are compared in ascending order, meaning the triggers with the lowest value activate first. You can change a trigger’s order value in the bottom left of EditGroup , and a trigger’s value must be larger than all other triggers before it in order to prevent breaking.
 
 {{< youtube 07Ras4igAMs >}}
 
-## Placement Priority:
+## Placement Priority
+
 In the case of 2 or more triggers having the same X position and the same order value, the most recently created trigger will activate first, with the oldest activating last. For example, copy + pasting a trigger means the copy will activate before the original.
 
 {{< youtube Kvk8a-bfHxM >}}
 
-## Order Inheritance:
+## Order Inheritance
+
 An important thing to note is that a trigger’s priority depends on the previous triggers’ priority, so the order of 2 triggers activated by different spawn triggers is based on the order of these spawn triggers.
 
 {{< youtube bI8iyrOKVnc >}}

--- a/content/docs/guides/triggers-2/randomizers-2-1.md
+++ b/content/docs/guides/triggers-2/randomizers-2-1.md
@@ -109,12 +109,11 @@ This randomizer abuses an interaction between the shake trigger and dual mode in
 
 Here's what it should look like.
 
-{{< img src="https://lh3.googleusercontent.com/d/1kOGzNoGNk4BxdJhh9IYYx9P5HQldqlPy" >}}
+{{< youtube 66jnPOmvqWY >}}
 
 This randomizer does not require any player input, and is fully random. However, it only supports 2 outcomes, requires Shake to be enabled, and cannot be playtested in the editor.
 
 # Sources
 
-- <https://youtu.be/LbPYygtpxJk
-- <https://youtu.be/guOzs1aU_Us
-- <https://youtu.be/tbzdZJQWaAc
+- [How I Made A Randomized Geometry Dash Level](<https://youtu.be/LbPYygtpxJk>)
+- [How I Made a RANDOM TRIGGER in Geometry Dash 2.1!](<https://www.youtube.com/watch?v=guOzs1aU_Us>)

--- a/content/docs/guides/triggers-2/stacking-properties.md
+++ b/content/docs/guides/triggers-2/stacking-properties.md
@@ -15,6 +15,7 @@ contributors:
   - chuckolate
   - notamoderatr
   - komatic5
+  - typexleta
 ---
 THIS GUIDE HAS MISSING EXAMPLES, DON'T MAKE PUBLIC YET
 

--- a/content/docs/guides/triggers-2/using-remap-properties.md
+++ b/content/docs/guides/triggers-2/using-remap-properties.md
@@ -22,9 +22,11 @@ tags:
 {{< /callout >}}
 
 ** **
+
 # 1: Spawn Remap Properties
 
 ## Abstraction
+
 Spawn remapping applies to every type of ID, not just groups. ItemIDs, Color Channels, BlockIDs, and so on, can all be remapped. The only exception is GradientIDs, as of Update 2.206.
 
 However for this to work, each ID type must have a unique OriginalID when remapping. In the example below, I could use Color Channel 1, Group 2, and BlockID 3, but not both Color Channel 1 and BlockID 1.
@@ -32,11 +34,13 @@ However for this to work, each ID type must have a unique OriginalID when remapp
 {{< img src="https://lh3.googleusercontent.com/d/1w4Ymd5XVTMPur0yDK4ItDwGryLq8xVlZ" >}}
 
 ## Priority
+
 If you use multiple remaps with the same OriginalID, only the highest NewID will actually get remapped. This only applies within the same spawn trigger, so you can remap the same OriginalID to multiple NewIDs by copy-pasting your trigger and changing the IDs accordingly.
 
 {{< img src="https://lh3.googleusercontent.com/d/1KLOYHLBoH57igpak4I6raTx4o8Xkub8v" >}}
 
 ## Inheritance
+
 Triggers activated by a Spawn Trigger can inherit the remapped IDs. This means that triggers activated by a remapped trigger will also be remapped, including other Spawn Remap triggers.
 
 However, this has some issues with the Instant Collision trigger, which will be explained in the Bugs section.
@@ -44,9 +48,11 @@ However, this has some issues with the Instant Collision trigger, which will be 
 {{< img src="https://lh3.googleusercontent.com/d/1R4-ees4r5-XHNGdmPptb6473r34nL-Pl" >}}
 
 ## Recursion
+
 You can remap the OriginalID and NewID in a spawn remap because of Remap Inheritance. This means your spawn remaps can carry over to other remaps.
 
 For example, a spawn trigger that remaps ID A to B and ID C to D, and activates a spawn trigger which remaps A to C, is the equivalent of remapping B to D.
+
 ## Non-Exclusivity across triggers
 
 Spawn triggers create new “instances” of the triggers they activate, which work independently from the original. Think of this like copying a file before opening it; the original is left unchanged. This means that spawn remaps create new independent instances of trigger setups that don’t have control over others.
@@ -58,7 +64,9 @@ However, since Stop triggers and Edit Advanced Follow cannot be remapped when st
 For stop triggers to know which instances they should affect, use ControlIDs instead of GroupIDs. Select the triggers you want to stop, then go to Edit Group -> Extra2 and choose a ControlID. Now enable “Use ControlID” in the stop trigger and type in the value in the “groupID” text box.
 
 Make sure for each new spawn trigger you also remap the ControlIDs used. Also note that ControlIDs can go up to 2^31 and aren’t limited by the 9999 ID limit.
+
 ## Exclusivity within Recursion
+
 Remap Recursion has another property which can lead to very undesirable outcomes. When remapping ID A to B with a spawn trigger, and using this trigger to activate another spawn trigger that remaps A to C, the game tries to create two different instances of the remap. Both remaps cannot be executed at the same time or the game will crash.
 
 Reset Remap is a solution to this. It effectively resets any recursion in the spawn triggers, which overrides the first instance and prevents a crash. In this example, we’ll enable it for the second spawn trigger.
@@ -66,7 +74,9 @@ Reset Remap is a solution to this. It effectively resets any recursion in the sp
 # 2: Bugs
 
 As of 2.206, remapping doesn’t work with some specific triggers. This part has some fixes and workarounds you should consider.
+
 ## Instant Collision
+
 **TrueID** can be remapped, but remapping does not travel through it via Inheritance.
 **FalseID** can neither be remapped nor does it allow remapping to travel through it.
 
@@ -89,14 +99,16 @@ With this setup you’ll also have to remap the ItemID used (3 in this case) alo
 ## Triggers with ID limits
 
 Spawn remaps can bypass the 9999 ID limit on triggers, more specifically for triggers that use itemIDs or controlIDs. This lets you use Item Comp triggers, for example, on negative itemIDs or 10000+ itemIDs.
+
 ## Storing values
+
 You can save a remap value for later use. This is thanks to Recursion, which lets you trap the remap value inside a loop, and release it when necessary.
 
 For example, consider this initial setup where we want to pulse different blocks using the same button. Each time we select a block, we toggle on its spawn trigger and toggle off the others. This can use a considerable amount of groupIDs if the number of blocks is high enough .
 
 This original version of the system was created by @Evere, where a spawn trigger that is part of the loop is toggled off at first (in this case, it’s the selected spawn trigger), and is toggled on when needed. It activates the pulse trigger in this example.
 
-{{< img src="https://lh3.googleusercontent.com/d/14cFb-YHiSQ24Ces-nuwl5Kq5e-YVWtwF" >}}
+{{< youtube oXioSg_5mZI >}}
 
 {{< img src="https://lh3.googleusercontent.com/d/1RFOvlQFz-75Wha9PMfW86AAh3FKluuJa" >}}
 
@@ -116,7 +128,7 @@ This original version of the system was created by @Evere, where a spawn trigger
 
 This setup can also use ItemIDs instead. When you want to pulse the selected blocks, a change in the ItemID is detected by the item comp trigger inside the loop, which activates the pulse trigger instead of the looping spawn trigger.
 
-{{< img src="https://lh3.googleusercontent.com/d/1cWeeNm4HbULKOj0jKPDkbFjgMwC7CZ2O" >}}
+{{< youtube 34LVyscf-b8 >}}
 
 {{< img src="https://lh3.googleusercontent.com/d/1j6GH7rRXOUjrSWxWbIURDQfmUr4C94KJ" >}}
 
@@ -135,4 +147,5 @@ This setup can also use ItemIDs instead. When you want to pulse the selected blo
 4. To activate the wanted triggers, change the value of ItemID 1 with a Pickup trigger as shown in the video.
 
 ## Dynamic Groups
+
 Spawn remaps can also be used to make Dynamic Groups. This is a setup made by @koma5 that lets you choose a target group for a trigger based on an ItemID’s value. You can read more about it in the [Making Data Structures](https://docs.google.com/document/d/17OohiVbf_m8fiL_1_FSl0Yn5NjBrE7dBMNRALGljp54/edit?usp=sharing) guide.

--- a/hugo_stats.json
+++ b/hugo_stats.json
@@ -989,6 +989,8 @@
       "code-blocks",
       "cognitive-mapping",
       "collision",
+      "collision-blocks",
+      "collision-triggers",
       "collisions",
       "collisions-1",
       "collisions-2",


### PR DESCRIPTION
Advances #4 

There are no more "None" messages serving as placeholders for media files. There's still missing media in the form of broken discord links, or videos/gifs embeded as images.