### PR TITLE
Decap Updates

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -102,12 +102,12 @@ jobs:
 
       - name: Build the site
         run: |
+          npm run predev
           hugo build \
             --gc \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/" \
             --cacheDir "${{ runner.temp }}/hugo_cache"
-          node scripts/copy-css.js
 
       - name: Cache save
         id: cache-save

--- a/.github/workflows/pr-testing.yaml
+++ b/.github/workflows/pr-testing.yaml
@@ -59,6 +59,6 @@ jobs:
 
       - name: Test Build
         run: |
-          node scripts/prepare-content.js
+          npm run predev
           hugo --gc --minify --cacheDir "${{ runner.temp }}/hugo_cache"
-          node scripts/copy-css.js
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 public
 resources
 static/admin/main.css
+static/images/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/thuliteio/doks.git"
   },
   "scripts": {
-    "predev": "node scripts/prepare-content.js && node scripts/copy-css.js",
+    "predev": "node scripts/prepare-content.js && node scripts/copy-css.js && node scripts/copy-assets-for-decap-preview.js",
     "create": "hugo new",
     "dev": "hugo server --disableFastRender --noHTTPCache",
     "format": "prettier **/** -w -c",

--- a/scripts/copy-assets-for-decap-preview.js
+++ b/scripts/copy-assets-for-decap-preview.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+
+const ASSETS_DIRECTORY = "assets/images";
+const DECAP_PREVIEW_DIRECTORY = "static/images";
+
+if (fs.existsSync(DECAP_PREVIEW_DIRECTORY)) {
+  fs.rmSync(DECAP_PREVIEW_DIRECTORY, {
+    recursive: true,
+    force: true,
+  });
+}
+
+fs.cpSync(
+  ASSETS_DIRECTORY,
+  DECAP_PREVIEW_DIRECTORY,
+  { recursive: true }
+);

--- a/static/admin/editor-components/gif.js
+++ b/static/admin/editor-components/gif.js
@@ -1,0 +1,32 @@
+CMS.registerEditorComponent({
+  id: "gif",
+  label: "Gif",
+  fields: [
+    { name: "src", label: "GIF URL", widget: "string" },
+    { name: "class", label: "Class", widget: "string", required: false },
+  ],
+
+  pattern: /{{<\s*gif\s+([^>]+)\s*>}}/s,
+
+  fromBlock(match) {
+    const attrs = match[1].trim();
+
+    const srcAttrMatch = attrs.match(/src\s*=\s*"?([^\s"]+)"?/);
+    const classAttrMatch = attrs.match(/class\s*=\s*"?([^\s"]+)"?/);
+
+    const src = srcAttrMatch ? srcAttrMatch[1] : "";
+    const className = classAttrMatch ? classAttrMatch[1] : "";
+
+    return { src: src, class: className };
+  },
+
+  toBlock(data) {
+    const src = data.src?.trim();
+    const className = data.className?.toString().trim();
+
+    if (className) {
+      return `{{< gif src="${src}" class="${className}" >}}`;
+    }
+    return `{{< gif src="${src}" >}}`;
+  },
+});

--- a/static/admin/editor-preview.js
+++ b/static/admin/editor-preview.js
@@ -8,6 +8,29 @@ import collections from '/admin/collections.js'
 
 const { h, createClass } = window;
 
+
+// image styling, valid for img and gif shortcodes.
+function renderImageShortcode(attrs) {
+  const srcMatch = attrs.match(/src\s*=\s*"?([^\s"]+)"?/);
+  const classMatch = attrs.match(/class\s*=\s*"?([^\s"]+)"?/);
+
+  const src = srcMatch ? srcMatch[1] : "";
+  const className = classMatch ? classMatch[1] : "";
+
+  const classStr = className ? `class="${className}"` : "";
+
+  // this is introduced so Decap searches from absolute routes if it encounters an internal website route.
+  // it keeps external urls intact.
+  const resolvedSrc = /^(https?:)?\/\//.test(src) || src.startsWith("/") ? src : `/${src}`;
+  console.log({
+    original: src,
+    resolved: resolvedSrc
+  });
+
+  return `<img src="${resolvedSrc}" ${classStr} loading="lazy" style="max-width: 100%; display: inline-block; vertical-align: middle; margin: 0 4px;" />`;
+}
+
+
 const PostPreview = createClass({
   render: function() {
     const { entry, getAsset } = this.props;
@@ -15,18 +38,15 @@ const PostPreview = createClass({
     let body = entry.getIn(['data', 'body']) || "";
 
     // {{< img >}} shortcode styling
-    body = body.replace(/{{<\s*img\s+([^>]+)\s*>}}/g, (match, attrs) => {
-        attrs = attrs.trim();
-        const srcMatch = attrs.match(/src\s*=\s*"?([^\s"]+)"?/);
-        const classMatch = attrs.match(/class\s*=\s*"?([^\s"]+)"?/);
+    body = body.replace(
+      /{{<\s*img\s+([^>]+)\s*>}}/g,
+      (match, attrs) => renderImageShortcode(attrs)
+    );
 
-        const src = srcMatch ? srcMatch[1] : "";
-        const className = classMatch ? classMatch[1] : "";
-
-        const classStr = className ? `class="${className}"` : "";
-
-        return `<img src="${src}" ${classStr} style="max-width: 100%; display: inline-block; vertical-align: middle; margin: 0 4px;" />`;
-      }
+    // {{< gif >}} shortcode styling
+    body = body.replace(
+      /{{<\s*gif\s+([^>]+)\s*>}}/g,
+      (match, attrs) => renderImageShortcode(attrs)
     );
 
     // {{< img-grid >}} shortcode styling

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -17,6 +17,7 @@
     <!-- Custom editor-components scripts -->
     <script type="module" src="/admin/editor-components/img.js"></script>
     <script type="module" src="/admin/editor-components/img-grid.js"></script>
+    <script type="module" src="/admin/editor-components/gif.js"></script>
     <script type="module" src="/admin/editor-components/youtube.js"></script>
     <script type="module" src="/admin/editor-components/callout.js"></script>
 

--- a/static/admin/override-main.css
+++ b/static/admin/override-main.css
@@ -25,3 +25,53 @@ code {
   padding: 3px;
   border-radius: 3px;
 }
+
+
+/* Note: emote css is manually copied from assets/scss/..., might introduce differences later on
+if the main files at assets are modified, but it doesn't matter that much */
+
+img.emote {
+    display: inline;
+    width: 1.55rem;
+    height: auto;
+    margin-bottom: 0.15rem;
+}
+
+img.smallemote {
+    display: inline;
+    height: 1.35rem;
+    width: auto;
+    margin-left: 2px;
+    margin-bottom: 0.15rem;
+}
+
+img.largeemote {
+    display: inline;
+    width: 2.15rem;
+    height: auto;
+    margin-bottom: 0.1rem;
+}
+
+img.headingemote {
+    display: inline-flex;
+    height: 4rem;
+    width: auto;
+    vertical-align: middle;
+    margin-bottom: 0rem;
+}
+
+h2 img.headingemote {
+    height: 3rem;
+}
+
+.latest-guide-item h2 img.headingemote {
+    height: 3rem;
+    vertical-align: sub;
+    margin: -3rem auto 0 auto;
+    transform: translateY(0.5rem);
+}
+
+h4 img.headingemote {
+    height: 2rem;
+    transform: translateY(-0.05rem);
+}


### PR DESCRIPTION
## What Changed
- Support for the `gif` shortcode was added for Decap. It is available as an editor component, and gifs now render on the preview panel.
- Fixed an issue where some images wouldn't load correctly because Decap was sending too many requests to Google servers. This was fixed using lazy loading on the rendered img & gif shortcodes in the preview panel.
- A script was added that copies what's inside `assets/images/` to a new `static/images` folder. This was made mainly so emotes could be rendered on Decap's preview panel.