### PR TITLE
Change script order on Build

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -102,12 +102,13 @@ jobs:
 
       - name: Build the site
         run: |
-          npm run predev
+          node scripts/copy-assets-for-decap-preview.js
           hugo build \
             --gc \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/" \
             --cacheDir "${{ runner.temp }}/hugo_cache"
+          node scripts/copy-css.js
 
       - name: Cache save
         id: cache-save


### PR DESCRIPTION
The copy-css.js script executes *after* the site is built.