### PR TITLE
update deploy.yaml

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -121,8 +121,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ github.workspace }}/dist
-          artifact_name: dist
+          path: ./public
+          artifact_name: 'github-pages'
         continue-on-error: true
 
   deploy:


### PR DESCRIPTION
third time is the charm. Attempting to fix the 'No artifacts named "github-pages" were found for this workflow run' bug as per [this info](https://github.com/actions/deploy-pages/issues/305).